### PR TITLE
Follow HTTP redirects

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -180,6 +180,7 @@ main(int argc, char * const argv[]) {
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, printData);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, true);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, REQUEST_TIMEOUT);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
 	for (int arg = 0; arg < argc; arg++) {
 		char url[URL_BUFFER_LEN];


### PR DESCRIPTION
Before this change:
```
$ ./bin/metar KSFO
<head><body> This object may be found <a HREF="https://tgftp.nws.noaa.gov/data/observations/metar/stations/KSFO.TXT">here</a> </body>%      
```

After this change:
```
$ ./bin/metar KSFO
2019/02/12 22:56
KSFO 122256Z 14007KT 10SM FEW070 SCT090 OVC100 09/02 A2991 RMK AO2 SLP128 T00940022
```
