### PR TITLE
fix: order of substitution variables in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MANDEST=$(PREFIX)/share/man/man1
 BINDEST=$(PREFIX)/bin
 
 $(BIN): $(BUILDDIR) $(SRCS)
-	$(CC) $(CFLAGS) $(INCLUDE) $(LDFLAGS) $(LDLIBS) -o $(BIN) $(SRCS)
+	$(CC) $(CFLAGS) $(INCLUDE) $(SRCS) $(LDFLAGS) $(LDLIBS) -o $(BIN)
 
 $(BUILDDIR):
 	mkdir $(BUILDDIR)


### PR DESCRIPTION
did not compile, so I changed order of command variables in Makefile